### PR TITLE
Added return types to the React components, fixing issues with inferred types

### DIFF
--- a/demo/useFakeMessages.tsx
+++ b/demo/useFakeMessages.tsx
@@ -18,7 +18,7 @@ export function useFakeMessages(speed = 1) {
 
   useEffect(() => {
     let wordCount = 0;
-    let timer: NodeJS.Timeout;
+    let timer: ReturnType<typeof setTimeout>;
 
     const update = () => {
       if (wordCount <= 0) {

--- a/package.json
+++ b/package.json
@@ -44,5 +44,6 @@
     "vite": "^5.4.1",
     "vite-plugin-dts": "^4.2.1",
     "@biomejs/biome": "^1.9.4"
-  }
+  },
+  "packageManager": "pnpm@9.12.3+sha512.cce0f9de9c5a7c95bef944169cc5dfe8741abfb145078c0d508b868056848a87c81e626246cb60967cbd7fd29a6c062ef73ff840d96b3c86c40ac92cf4a813ee"
 }

--- a/src/StickToBottom.tsx
+++ b/src/StickToBottom.tsx
@@ -17,6 +17,7 @@ import {
 import {
 	type GetTargetScrollTop,
 	type ScrollToBottom,
+	type StickToBottomInstance,
 	type StickToBottomOptions,
 	type StickToBottomState,
 	type StopScroll,
@@ -43,7 +44,7 @@ export interface StickToBottomProps
 	extends Omit<React.HTMLAttributes<HTMLDivElement>, "children">,
 		StickToBottomOptions {
 	contextRef?: React.Ref<StickToBottomContext>;
-	instance?: ReturnType<typeof useStickToBottom>;
+	instance?: StickToBottomInstance;
 	children: ((context: StickToBottomContext) => ReactNode) | ReactNode;
 }
 
@@ -61,7 +62,7 @@ export function StickToBottom({
 	targetScrollTop: currentTargetScrollTop,
 	contextRef,
 	...props
-}: StickToBottomProps) {
+}: StickToBottomProps): ReactNode {
 	const customTargetScrollTop = useRef<GetTargetScrollTop | null>(null);
 
 	const targetScrollTop = React.useCallback<GetTargetScrollTop>(
@@ -145,7 +146,7 @@ export namespace StickToBottom {
 		children: ((context: StickToBottomContext) => ReactNode) | ReactNode;
 	}
 
-	export function Content({ children, ...props }: ContentProps) {
+	export function Content({ children, ...props }: ContentProps): ReactNode {
 		const context = useStickToBottomContext();
 
 		return (
@@ -167,7 +168,7 @@ export namespace StickToBottom {
 /**
  * Use this hook inside a <StickToBottom> component to gain access to whether the component is at the bottom of the scrollable area.
  */
-export function useStickToBottomContext() {
+export function useStickToBottomContext(): StickToBottomContext {
 	const context = useContext(StickToBottomContext);
 	if (!context) {
 		throw new Error(

--- a/src/useStickToBottom.ts
+++ b/src/useStickToBottom.ts
@@ -146,7 +146,9 @@ globalThis.document?.addEventListener("click", () => {
 	mouseDown = false;
 });
 
-export const useStickToBottom = (options: StickToBottomOptions = {}) => {
+export const useStickToBottom = (
+	options: StickToBottomOptions = {},
+): StickToBottomInstance => {
 	const [escapedFromLock, updateEscapedFromLock] = useState(false);
 	const [isAtBottom, updateIsAtBottom] = useState(options.initial !== false);
 	const [isNearBottom, setIsNearBottom] = useState(false);
@@ -389,7 +391,7 @@ export const useStickToBottom = (options: StickToBottomOptions = {}) => {
 		[setIsAtBottom, isSelecting, state],
 	);
 
-	const stopScroll = useCallback(() => {
+	const stopScroll = useCallback((): void => {
 		setEscapedFromLock(true);
 		setIsAtBottom(false);
 	}, [setEscapedFromLock, setIsAtBottom]);
@@ -588,6 +590,19 @@ export const useStickToBottom = (options: StickToBottomOptions = {}) => {
 		state,
 	};
 };
+
+export interface StickToBottomInstance {
+	contentRef: React.MutableRefObject<HTMLElement | null> &
+		React.RefCallback<HTMLElement>;
+	scrollRef: React.MutableRefObject<HTMLElement | null> &
+		React.RefCallback<HTMLElement>;
+	scrollToBottom: ScrollToBottom;
+	stopScroll: StopScroll;
+	isAtBottom: boolean;
+	isNearBottom: boolean;
+	escapedFromLock: boolean;
+	state: StickToBottomState;
+}
 
 function useRefCallback<T extends (ref: HTMLElement | null) => any>(
 	callback: T,

--- a/src/useStickToBottom.ts
+++ b/src/useStickToBottom.ts
@@ -592,8 +592,10 @@ export const useStickToBottom = (
 };
 
 export interface StickToBottomInstance {
-	contentRef: React.MutableRefObject<HTMLElement | null>;
-	scrollRef: React.MutableRefObject<HTMLElement | null>;
+	contentRef: React.MutableRefObject<HTMLElement | null> &
+		React.RefCallback<HTMLElement>;
+	scrollRef: React.MutableRefObject<HTMLElement | null> &
+		React.RefCallback<HTMLElement>;
 	scrollToBottom: ScrollToBottom;
 	stopScroll: StopScroll;
 	isAtBottom: boolean;

--- a/src/useStickToBottom.ts
+++ b/src/useStickToBottom.ts
@@ -592,10 +592,8 @@ export const useStickToBottom = (
 };
 
 export interface StickToBottomInstance {
-	contentRef: React.MutableRefObject<HTMLElement | null> &
-		React.RefCallback<HTMLElement>;
-	scrollRef: React.MutableRefObject<HTMLElement | null> &
-		React.RefCallback<HTMLElement>;
+	contentRef: React.MutableRefObject<HTMLElement | null>;
+	scrollRef: React.MutableRefObject<HTMLElement | null>;
 	scrollToBottom: ScrollToBottom;
 	stopScroll: StopScroll;
 	isAtBottom: boolean;

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -16,6 +16,7 @@
 
     /* Linting */
     "strict": true,
+    "isolatedDeclarations": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true

--- a/tsconfig.demo.json
+++ b/tsconfig.demo.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "noEmit": true,
     "module": "ESNext",
-    "moduleResolution": "Bundler"
+    "moduleResolution": "Bundler",
+    "isolatedDeclarations": false
   },
   "include": ["demo"]
 }


### PR DESCRIPTION
I ran into an issue using this library where the inferred return types of the React components conflicted with my local setup.

See line 24 in the package's built outputs here:

https://www.npmjs.com/package/use-stick-to-bottom?activeTab=code

The return type is `import("react/jsx-runtime").JSX.Element`. Changing it to `ReactNode` fixed my issue.

For fun, I also added `isolatedDeclarations` to the `tsconfig.json` so that this never happens again.