### PR TITLE
feat: add stable scrollbar gutter to prevent layout shifts

### DIFF
--- a/src/StickToBottom.tsx
+++ b/src/StickToBottom.tsx
@@ -155,6 +155,7 @@ export namespace StickToBottom {
 				style={{
 					height: "100%",
 					width: "100%",
+					scrollbarGutter: "stable both-edges",
 				}}
 			>
 				<div {...props} ref={context.contentRef}>


### PR DESCRIPTION
## Summary
This PR adds `scrollbarGutter: "stable both-edges"` CSS property to the StickToBottom component's container to prevent layout shifts when the scrollbar appears or disappears.

## Changes
- Added `scrollbarGutter: "stable both-edges"` style property to the scrollable container in StickToBottom.tsx

## Impact
- Improves user experience by eliminating horizontal layout shifts
- Maintains consistent content width regardless of scrollbar visibility
- No breaking changes to the API