### PR TITLE
fix: use old JSX transform to support React 16

### DIFF
--- a/demo/Demo.tsx
+++ b/demo/Demo.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { StickToBottom, useStickToBottomContext } from '../src/StickToBottom';
 import { useFakeMessages } from './useFakeMessages';
 

--- a/demo/index.tsx
+++ b/demo/index.tsx
@@ -1,4 +1,5 @@
 import './index.css';
+import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { Demo } from './Demo.js';
 

--- a/demo/useFakeMessages.tsx
+++ b/demo/useFakeMessages.tsx
@@ -1,5 +1,5 @@
 import { LoremIpsum } from 'lorem-ipsum';
-import { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 
 const lorem = new LoremIpsum();
 

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -12,7 +12,7 @@
     "isolatedModules": true,
     "moduleDetection": "force",
     "declaration": true,
-    "jsx": "react-jsx",
+    "jsx": "react",
 
     /* Linting */
     "strict": true,


### PR DESCRIPTION
Switched to `jsx: "react"` to support React 16. The compiled output now uses `React.createElement` instead of `react/jsx-runtime`.

related issue: https://github.com/stackblitz-labs/use-stick-to-bottom/issues/27