### PR TITLE
feat: add scrollClassNames to StickToBottom.Content

### DIFF
--- a/src/StickToBottom.tsx
+++ b/src/StickToBottom.tsx
@@ -144,9 +144,14 @@ export namespace StickToBottom {
 	export interface ContentProps
 		extends Omit<React.HTMLAttributes<HTMLDivElement>, "children"> {
 		children: ((context: StickToBottomContext) => ReactNode) | ReactNode;
+		scrollClassName?: string;
 	}
 
-	export function Content({ children, ...props }: ContentProps): ReactNode {
+	export function Content({
+		children,
+		scrollClassName,
+		...props
+	}: ContentProps): ReactNode {
 		const context = useStickToBottomContext();
 
 		return (
@@ -156,6 +161,7 @@ export namespace StickToBottom {
 					height: "100%",
 					width: "100%",
 				}}
+				className={scrollClassName}
 			>
 				<div {...props} ref={context.contentRef}>
 					{typeof children === "function" ? children(context) : children}


### PR DESCRIPTION
**Background**
When I use StickToBottom Component, I wanna hide the scrollbar by set `{ scrollbar-width: none; }` css prop. But there is no prop I can use to control it.

**Change**
Add `scrollClassNames` prop to StickToBottom.Content component.