### PR TITLE
fix: override CSS scroll-behavior in programmatic scrollTop setter

### DIFF
--- a/src/useStickToBottom.ts
+++ b/src/useStickToBottom.ts
@@ -202,8 +202,14 @@ export const useStickToBottom = (
 			},
 			set scrollTop(scrollTop: number) {
 				if (scrollRef.current) {
+					// Override CSS scroll-behavior so programmatic scrollTop
+					// assignments take effect immediately and aren't intercepted
+					// by the browser's smooth scrolling.
+					const { scrollBehavior } = scrollRef.current.style;
+					scrollRef.current.style.scrollBehavior = "auto";
 					scrollRef.current.scrollTop = scrollTop;
 					state.ignoreScrollToTop = scrollRef.current.scrollTop;
+					scrollRef.current.style.scrollBehavior = scrollBehavior;
 				}
 			},
 


### PR DESCRIPTION
Fixes #29

## Problem

When `scroll-behavior: smooth` is set via CSS (e.g. from a design system, global stylesheet, or Tailwind base styles), direct `element.scrollTop = value` assignments are intercepted by the browser and animated smoothly — regardless of whether the library requested `"instant"` or spring-based scrolling.

This means `initial="instant"` still produces a visible smooth scroll animation, because the browser overrides the programmatic assignment.

## Root cause

The `scrollTop` setter on the internal state object writes directly to `scrollRef.current.scrollTop`, which the browser animates when CSS `scroll-behavior: smooth` is active on the element or an ancestor.

## Fix

Temporarily set `scroll-behavior: auto` on the scroll element around programmatic `scrollTop` writes, then restore the previous value. This is fully synchronous — no paint occurs with the temporary override, and user-initiated scrolling (wheel, touch) is unaffected.

```ts
set scrollTop(scrollTop: number) {
  if (scrollRef.current) {
    const { scrollBehavior } = scrollRef.current.style;
    scrollRef.current.style.scrollBehavior = "auto";
    scrollRef.current.scrollTop = scrollTop;
    state.ignoreScrollToTop = scrollRef.current.scrollTop;
    scrollRef.current.style.scrollBehavior = scrollBehavior;
  }
},
```

This ensures the library's own animation system (spring or instant) always controls scrolling, not the browser's CSS-driven smooth scroll.