### PR TITLE
fix: allow styling content scroll container

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,21 @@ function ScrollToBottom() {
 }
 ```
 
+`StickToBottom.Content` renders two nested elements: a scroll container and a content wrapper.
+Use `scrollClassName` or `scrollStyle` to style the scroll container itself, for example to customize scrollbars.
+Use `className` and other standard div props to style the content wrapper.
+
+```jsx
+<StickToBottom.Content
+  scrollClassName="scrollbar-none"
+  className="flex flex-col gap-4 p-6"
+>
+  {messages.map((message) => (
+    <Message key={message.id} message={message} />
+  ))}
+</StickToBottom.Content>
+```
+
 ### `useStickToBottom` Hook
 
 ```jsx

--- a/src/StickToBottom.tsx
+++ b/src/StickToBottom.tsx
@@ -145,11 +145,13 @@ export namespace StickToBottom {
 		extends Omit<React.HTMLAttributes<HTMLDivElement>, "children"> {
 		children: ((context: StickToBottomContext) => ReactNode) | ReactNode;
 		scrollClassName?: string;
+		scrollStyle?: React.CSSProperties;
 	}
 
 	export function Content({
 		children,
 		scrollClassName,
+		scrollStyle,
 		...props
 	}: ContentProps): ReactNode {
 		const context = useStickToBottomContext();
@@ -161,6 +163,7 @@ export namespace StickToBottom {
 					height: "100%",
 					width: "100%",
 					scrollbarGutter: "stable both-edges",
+					...scrollStyle,
 				}}
 				className={scrollClassName}
 			>


### PR DESCRIPTION
## Summary
- Adds `scrollStyle` to `StickToBottom.Content` so consumers can style the internal scroll container directly.
- Documents the existing `scrollClassName` prop and clarifies that `className` styles the inner content wrapper.

This is useful for chat UIs that need to customize or hide scrollbars on the actual scrollable element.

Closes #21.

## Test plan
- pnpm lint
- pnpm build