### PR TITLE
fix: clear resize observer on unmount

### DIFF
--- a/src/useStickToBottom.ts
+++ b/src/useStickToBottom.ts
@@ -510,6 +510,7 @@ export const useStickToBottom = (
 
 	const contentRef = useRefCallback((content) => {
 		state.resizeObserver?.disconnect();
+		state.resizeObserver = undefined;
 
 		if (!content) {
 			return;


### PR DESCRIPTION
## Summary
- Clears the stored `ResizeObserver` reference after disconnecting it when `StickToBottom.Content` unmounts or the content ref changes.

The observer was already disconnected through the ref callback path, but clearing the reference ensures the hook no longer retains a disconnected observer instance after cleanup.

Closes #31.

## Test plan
- pnpm lint
- pnpm build

Made with [Cursor](https://cursor.com)