### PR TITLE
fix: narrow component return types

### DIFF
--- a/src/StickToBottom.tsx
+++ b/src/StickToBottom.tsx
@@ -5,6 +5,7 @@
 
 import * as React from "react";
 import {
+	type ReactElement,
 	type ReactNode,
 	createContext,
 	useContext,
@@ -62,7 +63,7 @@ export function StickToBottom({
 	targetScrollTop: currentTargetScrollTop,
 	contextRef,
 	...props
-}: StickToBottomProps): ReactNode {
+}: StickToBottomProps): ReactElement {
 	const customTargetScrollTop = useRef<GetTargetScrollTop | null>(null);
 
 	const targetScrollTop = React.useCallback<GetTargetScrollTop>(
@@ -151,7 +152,7 @@ export namespace StickToBottom {
 		children,
 		scrollClassName,
 		...props
-	}: ContentProps): ReactNode {
+	}: ContentProps): ReactElement {
 		const context = useStickToBottomContext();
 
 		return (


### PR DESCRIPTION
## Summary
- Changes `StickToBottom` and `StickToBottom.Content` return types from `ReactNode` to `ReactElement`.

This keeps the runtime behavior unchanged while making the component types compatible with React versions before 19, where function components need to return `ReactElement | null` rather than any `ReactNode`.

Closes #23.

## Test plan
- pnpm lint
- pnpm build

Made with [Cursor](https://cursor.com)