### PR TITLE
feat: add an option to disable auto scroll while resizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.2.0
+
+Fork release maintained by https://github.com/duz52/.
+
+- Renamed the package metadata to `use-stick-to-bottom-extended`.
+- Added `resize: false` / `resize={false}` to disable ResizeObserver-driven automatic scroll-to-bottom after the initial layout.
+- Documented one-shot send scrolling for chat UIs that should scroll only when the user was already at the bottom and should not keep sticking during window resize.
+
 # 1.1.0
 
 Stable - Bumped version to signify a release with the new pausing feature https://x.com/samddenty/status/1907636864409817120. Also to start using proper semver, I was using the wrong semver versions for previous releases.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
-# `useStickToBottom`
+# `use-stick-to-bottom-extended`
 
 > Designed with AI chat bots in mind
 
-[![npm downloads](https://www.shieldcn.dev/npm/dm/use-stick-to-bottom.svg?variant=branded&size=sm)](https://www.npmjs.com/package/use-stick-to-bottom)
-[![Total npm downloads](https://www.shieldcn.dev/npm/dw/use-stick-to-bottom.svg?variant=secondary&size=sm)](https://www.npmjs.com/package/use-stick-to-bottom)
-[![@samdenty on X](https://www.shieldcn.dev/x/follow/samdenty.svg?variant=branded&size=sm)](https://x.com/samdenty)
+This package is a fork of the original [`use-stick-to-bottom`](https://github.com/stackblitz-labs/use-stick-to-bottom). The original implementation and copyright belong to StackBlitz/Sam Denty. This extended fork is maintained by [duz52](https://github.com/duz52/).
 
-**If you or your company finds this hook useful [Sponsor me on GitHub](https://github.com/sponsors/samdenty)**
+This fork adds `resize={false}` / `resize: false`, which disables ResizeObserver-driven automatic scrolling after initial layout. Use it when a chat should scroll once after sending a new message only if the user was already at the bottom, without continuing to stick to the bottom while the window is being resized.
 
 A lightweight **zero-dependency** React hook + Component that automatically sticks to the bottom of container and smoothly animates the content to keep it's visual position on screen whilst new content is being added.
 
@@ -27,7 +25,7 @@ A lightweight **zero-dependency** React hook + Component that automatically stic
 ## Installation
 
 ```bash
-npm install use-stick-to-bottom
+npm install github:duz52/use-stick-to-bottom-extended
 ```
 
 ## Usage
@@ -35,7 +33,7 @@ npm install use-stick-to-bottom
 ### `<StickToBottom>` Component
 
 ```jsx
-import { StickToBottom, useStickToBottomContext } from 'use-stick-to-bottom';
+import { StickToBottom, useStickToBottomContext } from 'use-stick-to-bottom-extended';
 
 function Chat() {
   return (
@@ -68,13 +66,63 @@ function ScrollToBottom() {
 }
 ```
 
+### One-shot send scroll without resize stickiness
+
+Set `resize={false}` to disable automatic scrolling from content resize events after the initial layout. Capture whether the user was at the bottom before appending the message, then scroll once after the message is rendered.
+
+```jsx
+import { useLayoutEffect, useRef, useState } from 'react';
+import { StickToBottom, useStickToBottomContext } from 'use-stick-to-bottom-extended';
+
+function Chat() {
+  const [messages, setMessages] = useState([]);
+
+  return (
+    <StickToBottom className="h-[50vh] relative" resize={false} initial="instant">
+      <ChatContent messages={messages} setMessages={setMessages} />
+    </StickToBottom>
+  );
+}
+
+function ChatContent({ messages, setMessages }) {
+  const { isAtBottom, scrollToBottom } = useStickToBottomContext();
+  const shouldScrollAfterSend = useRef(false);
+
+  const sendMessage = (text) => {
+    shouldScrollAfterSend.current = isAtBottom;
+    setMessages((current) => [...current, { id: crypto.randomUUID(), text }]);
+  };
+
+  useLayoutEffect(() => {
+    if (!shouldScrollAfterSend.current) {
+      return;
+    }
+
+    shouldScrollAfterSend.current = false;
+    scrollToBottom({ animation: 'instant' });
+  }, [messages.length, scrollToBottom]);
+
+  return (
+    <>
+      <StickToBottom.Content className="flex flex-col gap-4">
+        {messages.map((message) => (
+          <Message key={message.id} message={message} />
+        ))}
+      </StickToBottom.Content>
+
+      <ChatBox onSend={sendMessage} />
+    </>
+  );
+}
+```
+
 ### `useStickToBottom` Hook
 
 ```jsx
-import { useStickToBottom } from 'use-stick-to-bottom';
+import { useStickToBottom } from 'use-stick-to-bottom-extended';
 
 function Component() {
-  const { scrollRef, contentRef } = useStickToBottom();
+  const { scrollRef, contentRef } = useStickToBottom({ resize: false });
 
   return (
     <div style={{ overflow: 'auto' }} ref={scrollRef}>
@@ -87,3 +135,11 @@ function Component() {
   );
 }
 ```
+
+## Extended API
+
+### `resize: false`
+
+The original package accepts `resize` as an animation setting, such as `"smooth"`, `"instant"`, or a spring animation object. This fork also accepts `false`.
+
+When `resize` is `false`, the hook still observes content size changes so scroll state stays accurate, but it does not automatically call `scrollToBottom` for positive content resizes after the first layout. That lets applications implement explicit, one-shot scroll behavior on send while avoiding continued bottom locking during window resize.

--- a/package.json
+++ b/package.json
@@ -1,10 +1,16 @@
 {
-  "name": "use-stick-to-bottom",
+  "name": "use-stick-to-bottom-extended",
   "author": "Sam Denty <samddenty@gmail.com> (https://samdenty.io/)",
-  "description": "A lightweight React Hook intended mainly for AI chat applications, for smoothly sticking to bottom of messages",
-  "homepage": "https://use-stick-to-bottom.samdenty.io",
+  "contributors": [
+    {
+      "name": "duz52",
+      "url": "https://github.com/duz52/"
+    }
+  ],
+  "description": "A lightweight React Hook intended mainly for AI chat applications, with optional resize auto-scroll control",
+  "homepage": "https://github.com/duz52/use-stick-to-bottom-extended#readme",
   "private": false,
-  "version": "1.1.6",
+  "version": "1.2.0",
   "type": "module",
   "files": [
     "dist"
@@ -28,7 +34,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/samdenty/use-stick-to-bottom.git"
+    "url": "https://github.com/duz52/use-stick-to-bottom-extended.git"
+  },
+  "bugs": {
+    "url": "https://github.com/duz52/use-stick-to-bottom-extended/issues"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/src/StickToBottom.tsx
+++ b/src/StickToBottom.tsx
@@ -180,7 +180,7 @@ export function useStickToBottomContext(): StickToBottomContext {
 	const context = useContext(StickToBottomContext);
 	if (!context) {
 		throw new Error(
-			"use-stick-to-bottom component context must be used within a StickToBottom component",
+			"use-stick-to-bottom-extended component context must be used within a StickToBottom component",
 		);
 	}
 

--- a/src/useStickToBottom.ts
+++ b/src/useStickToBottom.ts
@@ -79,7 +79,7 @@ export type GetTargetScrollTop = (
 ) => number;
 
 export interface StickToBottomOptions extends SpringAnimation {
-	resize?: Animation;
+	resize?: Animation | false;
 	initial?: Animation | boolean;
 	targetScrollTop?: GetTargetScrollTop;
 }
@@ -366,6 +366,10 @@ export const useStickToBottom = (
 					 * requested animation.
 					 */
 					if (state.scrollTop < state.calculatedTargetScrollTop) {
+						if (optionsRef.current.resize === false) {
+							return state.isNearBottom;
+						}
+
 						return scrollToBottom({
 							animation: mergeAnimations(
 								optionsRef.current,
@@ -546,20 +550,25 @@ export const useStickToBottom = (
 				 * If it's a positive resize, scroll to the bottom when
 				 * we're already at the bottom.
 				 */
-				const animation = mergeAnimations(
-					optionsRef.current,
-					previousHeight
-						? optionsRef.current.resize
-						: optionsRef.current.initial,
-				);
+				const resize = previousHeight
+					? optionsRef.current.resize
+					: optionsRef.current.initial;
 
-				scrollToBottom({
-					animation,
-					wait: true,
-					preserveScrollPosition: true,
-					duration:
-						animation === "instant" ? undefined : RETAIN_ANIMATION_DURATION_MS,
-				});
+				if (resize === false) {
+					setIsAtBottom(state.isNearBottom);
+				} else {
+					const animation = mergeAnimations(optionsRef.current, resize);
+
+					scrollToBottom({
+						animation,
+						wait: true,
+						preserveScrollPosition: true,
+						duration:
+							animation === "instant"
+								? undefined
+								: RETAIN_ANIMATION_DURATION_MS,
+					});
+				}
 			} else {
 				/**
 				 * Else if it's a negative resize, check if we're near the bottom


### PR DESCRIPTION
This pull request updates the `useStickToBottom` hook to provide more granular control over scroll behavior during resize events. The main improvement is allowing the `resize` animation option to be explicitly disabled by setting it to `false`, preventing automatic scrolling in certain cases.

**Stick-to-bottom behavior customization:**

* The `resize` option in the `StickToBottomOptions` interface can now be set to `false`, allowing consumers to disable scroll-to-bottom animations on resize.
* The scroll logic in `useStickToBottom` now checks if `resize` is `false` and, in that case, avoids triggering a scroll and simply updates the bottom state. [[1]](diffhunk://#diff-b7be161fc09f61a38ef18657eae22c1d623fd691d98a8724968d16b85a3f2734R369-R372) [[2]](diffhunk://#diff-b7be161fc09f61a38ef18657eae22c1d623fd691d98a8724968d16b85a3f2734L549-R571)