### PR TITLE
feat: addition of `append` and `resize` options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Unreleased
+
+- Added `append` / `append={...}` to control automatic scroll-to-bottom when a
+  new direct child is appended to the content element.
+- Added `resize: false` / `resize={false}` to disable automatic
+  ResizeObserver-driven scroll-to-bottom after the initial layout.
+
 # 1.1.0
 
 Stable - Bumped version to signify a release with the new pausing feature https://x.com/samddenty/status/1907636864409817120. Also to start using proper semver, I was using the wrong semver versions for previous releases.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,11 @@ function ScrollToBottom() {
 import { useStickToBottom } from 'use-stick-to-bottom';
 
 function Component() {
-  const { scrollRef, contentRef } = useStickToBottom();
+  const { scrollRef, contentRef } = useStickToBottom({
+    initial: 'smooth',
+    append: 'smooth',
+    resize: false,
+  });
 
   return (
     <div style={{ overflow: 'auto' }} ref={scrollRef}>
@@ -87,3 +91,25 @@ function Component() {
   );
 }
 ```
+
+### Scroll on appended messages only
+
+Use `append` to control automatic scrolling when a new direct child is appended
+to the content element. Set `resize` to `false` to disable automatic scrolling
+for height changes that do not append a new direct child, such as streaming text
+growth, image loading, markdown reflow, or window resize.
+
+```jsx
+const { scrollRef, contentRef } = useStickToBottom({
+  initial: 'smooth',
+  append: 'smooth',
+  resize: false,
+});
+```
+
+With these options, the hook scrolls when a new message element is appended and
+the user was already at the bottom. It does not keep sticking to the bottom while
+that message grows or the window resizes.
+
+If `append` is omitted, appended children use the `resize` option, preserving the
+previous behavior.

--- a/src/StickToBottom.tsx
+++ b/src/StickToBottom.tsx
@@ -55,6 +55,7 @@ const useIsomorphicLayoutEffect =
 export function StickToBottom({
 	instance,
 	children,
+	append,
 	resize,
 	initial,
 	mass,
@@ -78,6 +79,7 @@ export function StickToBottom({
 		mass,
 		damping,
 		stiffness,
+		append,
 		resize,
 		initial,
 		targetScrollTop,

--- a/src/useStickToBottom.ts
+++ b/src/useStickToBottom.ts
@@ -79,6 +79,7 @@ export type GetTargetScrollTop = (
 ) => number;
 
 export interface StickToBottomOptions extends SpringAnimation {
+	append?: Animation | false;
 	resize?: Animation | false;
 	initial?: Animation | boolean;
 	targetScrollTop?: GetTargetScrollTop;
@@ -528,10 +529,14 @@ export const useStickToBottom = (
 		}
 
 		let previousHeight: number | undefined;
+		let previousChildCount: number | undefined;
 
 		state.resizeObserver = new ResizeObserver(([entry]) => {
 			const { height } = entry.contentRect;
 			const difference = height - (previousHeight ?? height);
+			const childCount = content.childElementCount;
+			const didAppend =
+				previousChildCount !== undefined && childCount > previousChildCount;
 
 			state.resizeDifference = difference;
 
@@ -551,7 +556,9 @@ export const useStickToBottom = (
 				 * we're already at the bottom.
 				 */
 				const resize = previousHeight
-					? optionsRef.current.resize
+					? didAppend
+						? (optionsRef.current.append ?? optionsRef.current.resize)
+						: optionsRef.current.resize
 					: optionsRef.current.initial;
 
 				if (resize === false) {
@@ -582,6 +589,7 @@ export const useStickToBottom = (
 			}
 
 			previousHeight = height;
+			previousChildCount = childCount;
 
 			/**
 			 * Reset the resize difference after the scroll event

--- a/src/useStickToBottom.ts
+++ b/src/useStickToBottom.ts
@@ -79,7 +79,7 @@ export type GetTargetScrollTop = (
 ) => number;
 
 export interface StickToBottomOptions extends SpringAnimation {
-	resize?: Animation;
+	resize?: Animation | false;
 	initial?: Animation | boolean;
 	targetScrollTop?: GetTargetScrollTop;
 }
@@ -366,6 +366,10 @@ export const useStickToBottom = (
 					 * requested animation.
 					 */
 					if (state.scrollTop < state.calculatedTargetScrollTop) {
+						if (optionsRef.current.resize === false) {
+							return state.isNearBottom;
+						}
+
 						return scrollToBottom({
 							animation: mergeAnimations(
 								optionsRef.current,
@@ -546,20 +550,25 @@ export const useStickToBottom = (
 				 * If it's a positive resize, scroll to the bottom when
 				 * we're already at the bottom.
 				 */
-				const animation = mergeAnimations(
-					optionsRef.current,
-					previousHeight
-						? optionsRef.current.resize
-						: optionsRef.current.initial,
-				);
+				const resize = previousHeight
+					? optionsRef.current.resize
+					: optionsRef.current.initial;
 
-				scrollToBottom({
-					animation,
-					wait: true,
-					preserveScrollPosition: true,
-					duration:
-						animation === "instant" ? undefined : RETAIN_ANIMATION_DURATION_MS,
-				});
+				if (resize === false) {
+					setIsAtBottom(state.isNearBottom);
+				} else {
+					const animation = mergeAnimations(optionsRef.current, resize);
+
+					scrollToBottom({
+						animation,
+						wait: true,
+						preserveScrollPosition: true,
+						duration:
+							animation === "instant"
+								? undefined
+								: RETAIN_ANIMATION_DURATION_MS,
+					});
+				}
 			} else {
 				/**
 				 * Else if it's a negative resize, check if we're near the bottom


### PR DESCRIPTION
This pull request introduces new options to the `use-stick-to-bottom` hook, giving developers finer control over automatic scroll-to-bottom behavior. The main improvements are the addition of `append` and `resize` options, which allow scrolling to be triggered only when new direct children are appended, or to disable scroll-on-resize entirely. Documentation and usage examples are updated accordingly.

**New scroll control options:**

* Added `append` / `append={...}` option to control automatic scroll-to-bottom when a new direct child is appended to the content element. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R7) [[2]](diffhunk://#diff-b7be161fc09f61a38ef18657eae22c1d623fd691d98a8724968d16b85a3f2734L82-R83) [[3]](diffhunk://#diff-b7be161fc09f61a38ef18657eae22c1d623fd691d98a8724968d16b85a3f2734R532-R539) [[4]](diffhunk://#diff-b7be161fc09f61a38ef18657eae22c1d623fd691d98a8724968d16b85a3f2734L549-R578) [[5]](diffhunk://#diff-b7be161fc09f61a38ef18657eae22c1d623fd691d98a8724968d16b85a3f2734R592)
* Added `resize: false` / `resize={false}` option to disable automatic ResizeObserver-driven scroll-to-bottom after the initial layout. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R7) [[2]](diffhunk://#diff-b7be161fc09f61a38ef18657eae22c1d623fd691d98a8724968d16b85a3f2734L82-R83) [[3]](diffhunk://#diff-b7be161fc09f61a38ef18657eae22c1d623fd691d98a8724968d16b85a3f2734R370-R373) [[4]](diffhunk://#diff-b7be161fc09f61a38ef18657eae22c1d623fd691d98a8724968d16b85a3f2734L549-R578)

**Documentation and usage updates:**

* Updated `README.md` with new usage examples and explanations for the `append` and `resize` options, clarifying their effects and recommended scenarios. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L77-R81) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R94-R115)
* Updated `CHANGELOG.md` to document the new options.

**Component and type updates:**

* Updated `StickToBottom` component and `StickToBottomOptions` interface to accept the new `append` and `resize` options. [[1]](diffhunk://#diff-d0da0d68265589bebb24c80504197787a9b61f866f73ba2dbab499fd23da7337R58) [[2]](diffhunk://#diff-d0da0d68265589bebb24c80504197787a9b61f866f73ba2dbab499fd23da7337R82) [[3]](diffhunk://#diff-b7be161fc09f61a38ef18657eae22c1d623fd691d98a8724968d16b85a3f2734L82-R83)