### PR TITLE
fix: re-anchor to bottom when the scroll container itself resizes

### DIFF
--- a/src/useStickToBottom.ts
+++ b/src/useStickToBottom.ts
@@ -36,6 +36,7 @@ export interface StickToBottomState {
 	isNearBottom: boolean;
 
 	resizeObserver?: ResizeObserver;
+	scrollResizeObserver?: ResizeObserver;
 }
 
 const DEFAULT_SPRING_ANIMATION = {
@@ -513,6 +514,69 @@ export const useStickToBottom = (
 		scrollRef.current?.removeEventListener("wheel", handleWheel);
 		scroll?.addEventListener("scroll", handleScroll, { passive: true });
 		scroll?.addEventListener("wheel", handleWheel, { passive: true });
+
+		state.scrollResizeObserver?.disconnect();
+		state.scrollResizeObserver = undefined;
+
+		if (!scroll) {
+			return;
+		}
+
+		let previousHeight: number | undefined;
+
+		state.scrollResizeObserver = new ResizeObserver(([entry]) => {
+			const { height } = entry.contentRect;
+			const difference = height - (previousHeight ?? height);
+
+			previousHeight = height;
+
+			if (!difference) {
+				return;
+			}
+
+			state.resizeDifference = difference;
+
+			setIsNearBottom(state.isNearBottom);
+
+			/**
+			 * When the scroll container itself shrinks (e.g. a flex sibling
+			 * grows), the content element doesn't change size so the content
+			 * ResizeObserver never fires - re-anchor to the bottom if we
+			 * were stuck there. A growing container needs no scroll, since
+			 * the browser clamps scrollTop for us.
+			 */
+			if (difference < 0 && state.isAtBottom) {
+				const animation = mergeAnimations(
+					optionsRef.current,
+					optionsRef.current.resize,
+				);
+
+				scrollToBottom({
+					animation,
+					wait: true,
+					preserveScrollPosition: true,
+					duration:
+						animation === "instant" ? undefined : RETAIN_ANIMATION_DURATION_MS,
+				});
+			}
+
+			/**
+			 * Reset the resize difference after the scroll event
+			 * has fired. Requires a rAF to wait for the scroll event,
+			 * and a setTimeout to wait for the other timeout we have in
+			 * resizeObserver in case the scroll event happens after the
+			 * resize event.
+			 */
+			requestAnimationFrame(() => {
+				setTimeout(() => {
+					if (state.resizeDifference === difference) {
+						state.resizeDifference = 0;
+					}
+				}, 1);
+			});
+		});
+
+		state.scrollResizeObserver.observe(scroll);
 	}, []);
 
 	const contentRef = useRefCallback((content) => {


### PR DESCRIPTION
## Problem

When the scroll container sits in a flex layout and a **sibling** element changes
height (a chat composer growing, a footer banner expanding), the scroll container
shrinks but the content element keeps its size. The `ResizeObserver` is only
attached to the content element, so no resize event fires: the scroll position
silently drifts away from the bottom while `isAtBottom` stays `true`, and the
sticky behavior is broken until the next content resize.

## Root cause

`useStickToBottom` observes only `contentRef`. A container-only resize
(`clientHeight` change with unchanged `scrollHeight`) moves the target scroll
position (`scrollHeight - 1 - clientHeight`) without producing any signal the
hook listens to.

## Fix

Attach a second `ResizeObserver` to the scroll element (`scrollRef`),
symmetrical to the existing content observer:

- **Container shrinks while stuck to the bottom** → re-anchor with the same
  `resize` animation, `wait: true` + `preserveScrollPosition: true` and the same
  retain duration the content-resize path uses. Nothing happens when the user
  has escaped the lock (`isAtBottom === false`).
- **Container grows** → no scroll is needed (the browser clamps `scrollTop`
  upwards), but the clamp fires a scroll event that looks like the user
  scrolling up. The observer records `state.resizeDifference` — exactly like
  the content observer — so `handleScroll` doesn't mistake the clamp for an
  escape and kick the user out of the bottom lock. Without this, collapsing
  the same footer banner would silently unstick the view.
- **Cleanup** mirrors the content observer: the observer is disconnected and
  the reference cleared whenever the scroll element changes or unmounts
  (same pattern #38 established for `state.resizeObserver`).

The new observer is exposed on state as `scrollResizeObserver`, next to the
existing `resizeObserver`.

## Verification

The repo has no automated test suite (no test script), so this was verified
manually with a repro of the exact issue scenario: a 60vh flex column containing
`<StickToBottom>` (`flex: 1; min-height: 0`, `initial="instant"`,
`resize="instant"`) above a footer sibling that toggles 48px ↔ 240px.

Measured `scrollTop` vs `scrollHeight - 1 - clientHeight` in the browser:

| Scenario | Before this fix | After this fix |
|---|---|---|
| At bottom, footer grows 48→240 (container shrinks 192px) | scrollTop stays 991, target 1183 → **192px drift**, stale `isAtBottom: true` | scrollTop 1183 == target, **0 drift**, `isAtBottom: true` |
| At bottom, footer collapses 240→48 (container grows, browser clamps) | — | clamp ignored, stays at bottom, `isAtBottom: true` (no escape) |
| Scrolled up (escaped), footer grows | — | no forced scroll (scrollTop unchanged), `isAtBottom: false` |

- `pnpm lint` ✅ (biome, no diagnostics)
- `pnpm build` ✅ (tsc)

Fixes #40
